### PR TITLE
Expose newrelic REST API endpoint to configure by user

### DIFF
--- a/contrib/newrelic.php
+++ b/contrib/newrelic.php
@@ -31,16 +31,18 @@ set('newrelic_revision', function () {
     return runLocally('git log -n 1 --format="%h"');
 });
 
+set('newrelic_endpoint', 'api.newrelic.com');
+
 desc('Notifies New Relic of deployment');
 task('newrelic:notify', function () {
-    if (($appId = get('newrelic_app_id')) && ($apiKey = get('newrelic_api_key'))) {
+    if (($appId = get('newrelic_app_id')) && ($apiKey = get('newrelic_api_key')) && ($endpoint = get('newrelic_endpoint'))) {
         $data = [
             'user' => get('user'),
             'revision' => get('newrelic_revision'),
             'description' => get('newrelic_description'),
         ];
 
-        Httpie::post("https://api.newrelic.com/v2/applications/$appId/deployments.json")
+        Httpie::post("https://$endpoint/v2/applications/$appId/deployments.json")
             ->header("X-Api-Key", $apiKey)
             ->query(['deployment' => $data])
             ->send();

--- a/docs/api.md
+++ b/docs/api.md
@@ -339,11 +339,10 @@ invoke('deploy:symlink');
 upload($source, string $destination, array $config = []): void
 ```
 
-Upload file or directory to host.
+Upload files or directories to host.
 
-> You may have noticed that there is a trailing slash (/) at the end of the first argument in the above command, this is necessary to mean “the contents of build“.
->
-> The alternative, without the trailing slash, would place build, including the directory, within public. This would create a hierarchy that looks like: {{release_path}}/public/build
+> To upload the _contents_ of a directory, include a trailing slash (eg `upload('build/', '{{release_path}}/public');`).  
+> Without the trailing slash, the build directory itself will be uploaded (resulting in `{{release_path}}/public/build`).  
 
  The `$config` array supports the following keys:
 
@@ -352,6 +351,10 @@ Upload file or directory to host.
 - `timeout` for `Process::fromShellCommandline()` (`null` by default)
 - `progress_bar` to display upload/download progress
 - `display_stats` to display rsync set of statistics
+
+Note: due to the way php escapes command line arguments, list-notation for the rsync `--exclude={'file','anotherfile'}` option will not work.  
+A workaround is to add a separate `--exclude=file` argument for each exclude to `options` (also, _do not_ wrap the filename/filter in quotes).
+An alternative might be to write the excludes to a temporary file (one per line) and use `--exclude-from=temporary_file` argument instead.
 
 
 

--- a/docs/contrib/newrelic.md
+++ b/docs/contrib/newrelic.md
@@ -17,6 +17,7 @@ require 'contrib/newrelic.php';
 - `newrelic_app_id` – newrelic's app id
 - `newrelic_api_key` – newrelic's api key
 - `newrelic_description` – message to send
+- `newrelic_endpoint` – newrelic's REST API endpoint
 
 ## Usage
 
@@ -60,11 +61,21 @@ return runLocally('git log -n 1 --format="%h"');
 ```
 
 
+### newrelic_endpoint
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L34)
+
+
+
+```php title="Default value"
+api.newrelic.com
+```
+
+
 
 ## Tasks
 
 ### newrelic:notify
-[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L35)
+[Source](https://github.com/deployphp/deployer/blob/master/contrib/newrelic.php#L37)
 
 Notifies New Relic of deployment.
 

--- a/docs/recipe/laravel.md
+++ b/docs/recipe/laravel.md
@@ -92,6 +92,7 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
     'storage/app/public',
     'storage/framework',
     'storage/framework/cache',
+    'storage/framework/cache/data',
     'storage/framework/sessions',
     'storage/framework/views',
     'storage/logs',
@@ -100,7 +101,7 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 
 ### log_files
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L21)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L22)
 
 
 
@@ -110,7 +111,7 @@ Overrides [writable_dirs](/docs/recipe/deploy/writable.md#writable_dirs) from `r
 
 
 ### laravel_version
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L22)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L23)
 
 
 
@@ -125,7 +126,7 @@ return $matches[0][0] ?? 5.5;
 ## Tasks
 
 ### artisan:down
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L89)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L90)
 
 Puts the application into maintenance / demo mode.
 
@@ -133,7 +134,7 @@ Puts the application into maintenance / demo mode.
 
 
 ### artisan:up
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L92)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L93)
 
 Brings the application out of maintenance mode.
 
@@ -141,7 +142,7 @@ Brings the application out of maintenance mode.
 
 
 ### artisan:&#8203;key:generate
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L99)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L100)
 
 Sets the application key.
 
@@ -149,7 +150,7 @@ Sets the application key.
 
 
 ### artisan:passport:keys
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L102)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L103)
 
 Creates the encryption keys for API authentication.
 
@@ -157,7 +158,7 @@ Creates the encryption keys for API authentication.
 
 
 ### artisan:db:seed
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L109)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L110)
 
 Seeds the database with records.
 
@@ -165,7 +166,7 @@ Seeds the database with records.
 
 
 ### artisan:migrate
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L112)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L113)
 
 Runs the database migrations.
 
@@ -173,7 +174,7 @@ Runs the database migrations.
 
 
 ### artisan:migrate:fresh
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L115)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L116)
 
 Drops all tables and re-run all migrations.
 
@@ -181,7 +182,7 @@ Drops all tables and re-run all migrations.
 
 
 ### artisan:migrate:rollback
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L118)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L119)
 
 Rollbacks the last database migration.
 
@@ -189,7 +190,7 @@ Rollbacks the last database migration.
 
 
 ### artisan:migrate:status
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L121)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L122)
 
 Shows the status of each migration.
 
@@ -197,7 +198,7 @@ Shows the status of each migration.
 
 
 ### artisan:cache:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L128)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L129)
 
 Flushes the application cache.
 
@@ -205,7 +206,7 @@ Flushes the application cache.
 
 
 ### artisan:config:cache
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L131)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L132)
 
 Creates a cache file for faster configuration loading.
 
@@ -213,7 +214,7 @@ Creates a cache file for faster configuration loading.
 
 
 ### artisan:config:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L134)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L135)
 
 Removes the configuration cache file.
 
@@ -221,7 +222,7 @@ Removes the configuration cache file.
 
 
 ### artisan:event:cache
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L137)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L138)
 
 Discovers and cache the application\'s events and listeners.
 
@@ -229,7 +230,7 @@ Discovers and cache the application\'s events and listeners.
 
 
 ### artisan:event:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L140)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L141)
 
 Clears all cached events and listeners.
 
@@ -237,7 +238,7 @@ Clears all cached events and listeners.
 
 
 ### artisan:event:list
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L143)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L144)
 
 Lists the application\'s events and listeners.
 
@@ -245,7 +246,7 @@ Lists the application\'s events and listeners.
 
 
 ### artisan:optimize
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L146)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L147)
 
 Cache the framework bootstrap files.
 
@@ -253,7 +254,7 @@ Cache the framework bootstrap files.
 
 
 ### artisan:optimize:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L149)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L150)
 
 Removes the cached bootstrap files.
 
@@ -261,7 +262,7 @@ Removes the cached bootstrap files.
 
 
 ### artisan:route:cache
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L152)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L153)
 
 Creates a route cache file for faster route registration.
 
@@ -269,7 +270,7 @@ Creates a route cache file for faster route registration.
 
 
 ### artisan:route:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L155)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L156)
 
 Removes the route cache file.
 
@@ -277,7 +278,7 @@ Removes the route cache file.
 
 
 ### artisan:route:list
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L158)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L159)
 
 Lists all registered routes.
 
@@ -285,7 +286,7 @@ Lists all registered routes.
 
 
 ### artisan:storage:link
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L161)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L162)
 
 Creates the symbolic links configured for the application.
 
@@ -293,7 +294,7 @@ Creates the symbolic links configured for the application.
 
 
 ### artisan:view:cache
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L164)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L165)
 
 Compiles all of the application\'s Blade templates.
 
@@ -301,7 +302,7 @@ Compiles all of the application\'s Blade templates.
 
 
 ### artisan:view:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L167)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L168)
 
 Clears all compiled view files.
 
@@ -309,7 +310,7 @@ Clears all compiled view files.
 
 
 ### artisan:queue:failed
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L174)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L175)
 
 Lists all of the failed queue jobs.
 
@@ -317,7 +318,7 @@ Lists all of the failed queue jobs.
 
 
 ### artisan:queue:flush
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L177)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L178)
 
 Flushes all of the failed queue jobs.
 
@@ -325,7 +326,7 @@ Flushes all of the failed queue jobs.
 
 
 ### artisan:queue:restart
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L180)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L181)
 
 Restarts queue worker daemons after their current job.
 
@@ -333,7 +334,7 @@ Restarts queue worker daemons after their current job.
 
 
 ### artisan:horizon
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L183)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L184)
 
 Starts a master supervisor in the foreground.
 
@@ -341,7 +342,7 @@ Starts a master supervisor in the foreground.
 
 
 ### artisan:horizon:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L186)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L187)
 
 Deletes all of the jobs from the specified queue.
 
@@ -349,7 +350,7 @@ Deletes all of the jobs from the specified queue.
 
 
 ### artisan:horizon:continue
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L189)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L190)
 
 Instructs the master supervisor to continue processing jobs.
 
@@ -357,7 +358,7 @@ Instructs the master supervisor to continue processing jobs.
 
 
 ### artisan:horizon:list
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L192)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L193)
 
 Lists all of the deployed machines.
 
@@ -365,7 +366,7 @@ Lists all of the deployed machines.
 
 
 ### artisan:horizon:pause
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L195)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L196)
 
 Pauses the master supervisor.
 
@@ -373,7 +374,7 @@ Pauses the master supervisor.
 
 
 ### artisan:horizon:purge
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L198)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L199)
 
 Terminates any rogue Horizon processes.
 
@@ -381,7 +382,7 @@ Terminates any rogue Horizon processes.
 
 
 ### artisan:horizon:status
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L201)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L202)
 
 Gets the current status of Horizon.
 
@@ -389,7 +390,7 @@ Gets the current status of Horizon.
 
 
 ### artisan:horizon:terminate
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L204)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L205)
 
 Terminates the master supervisor so it can be restarted.
 
@@ -397,7 +398,7 @@ Terminates the master supervisor so it can be restarted.
 
 
 ### artisan:&#8203;telescope:clear
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L211)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L212)
 
 Clears all entries from Telescope.
 
@@ -405,7 +406,7 @@ Clears all entries from Telescope.
 
 
 ### artisan:&#8203;telescope:prune
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L214)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L215)
 
 Prunes stale entries from the Telescope database.
 
@@ -413,7 +414,7 @@ Prunes stale entries from the Telescope database.
 
 
 ### artisan:octane
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L221)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L222)
 
 Starts the octane server.
 
@@ -421,7 +422,7 @@ Starts the octane server.
 
 
 ### artisan:octane:reload
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L224)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L225)
 
 Reloads the octane server.
 
@@ -429,7 +430,7 @@ Reloads the octane server.
 
 
 ### artisan:octane:stop
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L227)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L228)
 
 Stops the octane server.
 
@@ -437,7 +438,7 @@ Stops the octane server.
 
 
 ### artisan:octane:status
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L230)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L231)
 
 Check the status of the octane server.
 
@@ -445,7 +446,7 @@ Check the status of the octane server.
 
 
 ### deploy
-[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L236)
+[Source](https://github.com/deployphp/deployer/blob/master/recipe/laravel.php#L237)
 
 Deploys your project.
 

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -14,6 +14,7 @@ set('writable_dirs', [
     'storage/app/public',
     'storage/framework',
     'storage/framework/cache',
+    'storage/framework/cache/data',
     'storage/framework/sessions',
     'storage/framework/views',
     'storage/logs',

--- a/recipe/laravel.php
+++ b/recipe/laravel.php
@@ -106,19 +106,19 @@ task('artisan:passport:keys', artisan('passport:keys'));
  */
 
 desc('Seeds the database with records');
-task('artisan:db:seed', artisan('db:seed --force', ['showOutput']));
+task('artisan:db:seed', artisan('db:seed --force', ['skipIfNoEnv', 'showOutput']));
 
 desc('Runs the database migrations');
 task('artisan:migrate', artisan('migrate --force', ['skipIfNoEnv']));
 
 desc('Drops all tables and re-run all migrations');
-task('artisan:migrate:fresh', artisan('migrate:fresh --force'));
+task('artisan:migrate:fresh', artisan('migrate:fresh --force', ['skipIfNoEnv']));
 
 desc('Rollbacks the last database migration');
-task('artisan:migrate:rollback', artisan('migrate:rollback --force', ['showOutput']));
+task('artisan:migrate:rollback', artisan('migrate:rollback --force', ['skipIfNoEnv', 'showOutput']));
 
 desc('Shows the status of each migration');
-task('artisan:migrate:status', artisan('migrate:status', ['showOutput']));
+task('artisan:migrate:status', artisan('migrate:status', ['skipIfNoEnv', 'showOutput']));
 
 /*
  * Cache and optimizations.

--- a/recipe/provision/databases.php
+++ b/recipe/provision/databases.php
@@ -58,6 +58,6 @@ task('provision:mariadb', function () {
 desc('Provision PostgreSQL');
 task('provision:postgresql', function () {
     run('apt-get install -y postgresql postgresql-contrib', ['env' => ['DEBIAN_FRONTEND' => 'noninteractive'], 'timeout' => 900]);
-    run('sudo -u postgres createuser deployer');
-    run('sudo -u postgres createdb deployer');
+    run('sudo -u postgres createuser {{db_user}}');
+    run('sudo -u postgres createdb {{db_name}');
 });

--- a/src/functions.php
+++ b/src/functions.php
@@ -556,11 +556,10 @@ function invoke(string $taskName): void
 }
 
 /**
- * Upload file or directory to host.
+ * Upload files or directories to host.
  *
- * > You may have noticed that there is a trailing slash (/) at the end of the first argument in the above command, this is necessary to mean “the contents of build“.
- * >
- * > The alternative, without the trailing slash, would place build, including the directory, within public. This would create a hierarchy that looks like: {{release_path}}/public/build
+ * > To upload the _contents_ of a directory, include a trailing slash (eg `upload('build/', '{{release_path}}/public');`).  
+ * > Without the trailing slash, the build directory itself will be uploaded (resulting in `{{release_path}}/public/build`).  
  *
  *  The `$config` array supports the following keys:
  *
@@ -569,6 +568,10 @@ function invoke(string $taskName): void
  * - `timeout` for `Process::fromShellCommandline()` (`null` by default)
  * - `progress_bar` to display upload/download progress
  * - `display_stats` to display rsync set of statistics
+ *
+ * Note: due to the way php escapes command line arguments, list-notation for the rsync `--exclude={'file','anotherfile'}` option will not work.  
+ * A workaround is to add a separate `--exclude=file` argument for each exclude to `options` (also, _do not_ wrap the filename/filter in quotes).
+ * An alternative might be to write the excludes to a temporary file (one per line) and use `--exclude-from=temporary_file` argument instead.
  *
  * @param string|string[] $source
  * @param array $config


### PR DESCRIPTION
For EU region the REST API endpoint is different and users should be able to change it otherwise deployment notifications don't appear in their projects.

https://docs.newrelic.com/docs/accounts/accounts-billing/account-setup/choose-your-data-center/ 

- [ ] Bug fix #…?
- [x] New feature?
- [ ] BC breaks?
- [ ] Tests added?
- [x] Docs added?

      Please, regenerate docs by running next command:
      $ php bin/docgen
